### PR TITLE
Enforce ledger previous_hash uniqueness and retry-on-conflict; add frontend API client and InputBox

### DIFF
--- a/backend/app/db/migrations.py
+++ b/backend/app/db/migrations.py
@@ -27,6 +27,22 @@ def _has_previous_hash_uniqueness(engine: Engine) -> bool:
     return False
 
 
+def _has_duplicate_previous_hashes(engine: Engine) -> bool:
+    query = text(
+        """
+        SELECT 1
+        FROM ledger_events
+        WHERE previous_hash IS NOT NULL
+        GROUP BY previous_hash
+        HAVING COUNT(*) > 1
+        LIMIT 1
+        """
+    )
+
+    with engine.begin() as connection:
+        return connection.execute(query).first() is not None
+
+
 def ensure_ledger_previous_hash_uniqueness(engine: Engine) -> None:
     """Apply a one-time schema fix for existing deployments.
 
@@ -42,17 +58,15 @@ def ensure_ledger_previous_hash_uniqueness(engine: Engine) -> None:
     if _has_previous_hash_uniqueness(engine):
         return
 
-    dialect = engine.dialect.name
-    if dialect == "postgresql":
-        statement = (
-            f"ALTER TABLE {TABLE_NAME} "
-            f"ADD CONSTRAINT {UNIQUE_NAME} UNIQUE ({COLUMN_NAME})"
-        )
-    else:
-        statement = (
-            f"CREATE UNIQUE INDEX {UNIQUE_NAME} "
-            f"ON {TABLE_NAME} ({COLUMN_NAME})"
+    if _has_duplicate_previous_hashes(engine):
+        raise RuntimeError(
+            "Cannot apply previous_hash uniqueness: existing duplicate ledger head links found. "
+            "Please deduplicate ledger_events.previous_hash values before startup."
         )
 
+    statement = (
+        f"CREATE UNIQUE INDEX IF NOT EXISTS {UNIQUE_NAME} "
+        f"ON {TABLE_NAME} ({COLUMN_NAME})"
+    )
     with engine.begin() as connection:
         connection.execute(text(statement))

--- a/backend/app/db/migrations.py
+++ b/backend/app/db/migrations.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+
+
+UNIQUE_NAME = "uq_ledger_events_previous_hash"
+TABLE_NAME = "ledger_events"
+COLUMN_NAME = "previous_hash"
+
+
+def _has_previous_hash_uniqueness(engine: Engine) -> bool:
+    inspector = inspect(engine)
+
+    for constraint in inspector.get_unique_constraints(TABLE_NAME):
+        columns = set(constraint.get("column_names") or [])
+        if columns == {COLUMN_NAME}:
+            return True
+
+    for index in inspector.get_indexes(TABLE_NAME):
+        if not index.get("unique"):
+            continue
+        columns = set(index.get("column_names") or [])
+        if columns == {COLUMN_NAME}:
+            return True
+
+    return False
+
+
+def ensure_ledger_previous_hash_uniqueness(engine: Engine) -> None:
+    """Apply a one-time schema fix for existing deployments.
+
+    Base.metadata.create_all(...) creates missing tables, but will not add newly
+    declared constraints to tables that already exist. This function backfills
+    the ledger head uniqueness requirement for upgraded databases.
+    """
+
+    inspector = inspect(engine)
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+
+    if _has_previous_hash_uniqueness(engine):
+        return
+
+    dialect = engine.dialect.name
+    if dialect == "postgresql":
+        statement = (
+            f"ALTER TABLE {TABLE_NAME} "
+            f"ADD CONSTRAINT {UNIQUE_NAME} UNIQUE ({COLUMN_NAME})"
+        )
+    else:
+        statement = (
+            f"CREATE UNIQUE INDEX {UNIQUE_NAME} "
+            f"ON {TABLE_NAME} ({COLUMN_NAME})"
+        )
+
+    with engine.begin() as connection:
+        connection.execute(text(statement))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,10 +2,12 @@ from fastapi import FastAPI
 
 from app.api.routes.governance import router as governance_router
 from app.api.routes.pios import router as pios_router
+from app.db.migrations import ensure_ledger_previous_hash_uniqueness
 from app.db.session import engine
 from app.models.sql_models import Base
 
 app = FastAPI(title="FORNIX Governance API")
 Base.metadata.create_all(bind=engine)
+ensure_ledger_previous_hash_uniqueness(engine)
 app.include_router(governance_router)
 app.include_router(pios_router)

--- a/backend/app/models/sql_models.py
+++ b/backend/app/models/sql_models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Text, String
+from sqlalchemy import JSON, DateTime, ForeignKey, Text, String, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -35,6 +35,9 @@ class VaultEntryTable(Base):
 
 class LedgerEventTable(Base):
     __tablename__ = "ledger_events"
+    __table_args__ = (
+        UniqueConstraint("previous_hash", name="uq_ledger_events_previous_hash"),
+    )
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     event_type: Mapped[str] = mapped_column(String(64), nullable=False)

--- a/backend/app/services/pios_service.py
+++ b/backend/app/services/pios_service.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from uuid import uuid4
 
 from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.sql_models import LedgerEventTable, VaultEntryTable
@@ -37,42 +38,49 @@ class PersonalIntelligenceService:
 
     def create_entry(self, payload: EntryCreate) -> tuple[EntryRead, LedgerEventRead]:
         content_hash = self._sha256(payload.content)
-        entry_id = f"entry-{uuid4().hex}"
-        now = datetime.utcnow()
 
-        entry = VaultEntryTable(
-            id=entry_id,
-            entry_type=payload.entryType,
-            title=payload.title,
-            content=payload.content,
-            source_uri=payload.sourceUri,
-            content_hash=content_hash,
-            created_at=now,
-        )
-        self.db.add(entry)
+        for _ in range(3):
+            now = datetime.utcnow()
+            entry = VaultEntryTable(
+                id=f"entry-{uuid4().hex}",
+                entry_type=payload.entryType,
+                title=payload.title,
+                content=payload.content,
+                source_uri=payload.sourceUri,
+                content_hash=content_hash,
+                created_at=now,
+            )
 
-        self._acquire_ledger_head_lock()
-        previous_event = (
-            self.db.query(LedgerEventTable)
-            .with_for_update()
-            .order_by(LedgerEventTable.created_at.desc())
-            .first()
-        )
-        previous_hash = previous_event.event_hash if previous_event else None
+            try:
+                self._acquire_ledger_head_lock()
+                previous_event = (
+                    self.db.query(LedgerEventTable)
+                    .with_for_update()
+                    .order_by(LedgerEventTable.created_at.desc())
+                    .first()
+                )
+                previous_hash = previous_event.event_hash if previous_event else None
 
-        receipt_seed = "|".join([entry.id, content_hash, previous_hash or "genesis", now.isoformat()])
-        event = LedgerEventTable(
-            id=f"evt-{uuid4().hex}",
-            event_type="entry.captured",
-            entry_id=entry.id,
-            event_hash=self._sha256(receipt_seed),
-            previous_hash=previous_hash,
-            created_at=now,
-        )
-        self.db.add(event)
-        self.db.commit()
+                receipt_seed = "|".join(
+                    [entry.id, content_hash, previous_hash or "genesis", now.isoformat()]
+                )
+                event = LedgerEventTable(
+                    id=f"evt-{uuid4().hex}",
+                    event_type="entry.captured",
+                    entry_id=entry.id,
+                    event_hash=self._sha256(receipt_seed),
+                    previous_hash=previous_hash,
+                    created_at=now,
+                )
 
-        return self._to_entry_read(entry), self._to_event_read(event)
+                self.db.add(entry)
+                self.db.add(event)
+                self.db.commit()
+                return self._to_entry_read(entry), self._to_event_read(event)
+            except IntegrityError:
+                self.db.rollback()
+
+        raise RuntimeError("Could not append ledger event after multiple retries.")
 
     def _acquire_ledger_head_lock(self) -> None:
         """Serialize append operations so each event links to a unique predecessor."""

--- a/src/api.js
+++ b/src/api.js
@@ -6,7 +6,23 @@ const API_BASE =
     ? rawBase.trim().replace(/\/+$/, '')
     : 'http://localhost:8000';
 
-const PIOS_PREFIX = '/api/v1/pios';
+function piosPath(path) {
+  const normalized = path.startsWith('/') ? path.slice(1) : path;
+
+  if (API_BASE.endsWith('/api/v1/pios')) {
+    return `/${normalized}`;
+  }
+
+  if (API_BASE.endsWith('/api/v1')) {
+    return `/pios/${normalized}`;
+  }
+
+  if (API_BASE.endsWith('/api')) {
+    return `/v1/pios/${normalized}`;
+  }
+
+  return `/api/v1/pios/${normalized}`;
+}
 
 function extractErrorMessage(error) {
   if (axios.isCancel?.(error) || error?.code === 'ERR_CANCELED') {
@@ -103,7 +119,7 @@ export async function checkHealth(signal) {
 }
 
 export async function submitProblem(payload, signal) {
-  const response = await api.post(`${PIOS_PREFIX}/entries`, toEntryPayload(payload), {
+  const response = await api.post(piosPath('/entries'), toEntryPayload(payload), {
     signal,
   });
 
@@ -111,7 +127,7 @@ export async function submitProblem(payload, signal) {
 }
 
 export async function fetchTimeline(signal) {
-  const response = await api.get(`${PIOS_PREFIX}/timeline`, { signal });
+  const response = await api.get(piosPath('/timeline'), { signal });
   return response.data;
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,113 @@
+import axios from 'axios';
+
+const rawBase = import.meta.env.VITE_API_BASE;
+const API_BASE =
+  typeof rawBase === 'string' && rawBase.trim()
+    ? rawBase.trim().replace(/\/+$/, '')
+    : 'http://localhost:8000';
+
+function extractErrorMessage(error) {
+  if (axios.isCancel?.(error) || error?.code === 'ERR_CANCELED') {
+    return 'Request cancelled';
+  }
+
+  if (error?.code === 'ECONNABORTED') {
+    return 'Request timed out';
+  }
+
+  const status = error?.response?.status;
+  const data = error?.response?.data;
+
+  const serverMessage =
+    data?.detail ||
+    data?.message ||
+    data?.error ||
+    (Array.isArray(data?.errors) ? data.errors.join(', ') : null);
+
+  if (serverMessage) {
+    return String(serverMessage);
+  }
+
+  if (status === 400) return 'Bad request';
+  if (status === 401) return 'Unauthorized';
+  if (status === 403) return 'Forbidden';
+  if (status === 404) return 'Endpoint not found';
+  if (status === 409) return 'Conflict';
+  if (status === 422) return 'Validation failed';
+  if (status === 429) return 'Rate limited';
+  if (typeof status === 'number' && status >= 500) return 'Server error';
+
+  return error?.message || 'Network request failed';
+}
+
+const api = axios.create({
+  baseURL: API_BASE,
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => Promise.reject(new Error(extractErrorMessage(error)))
+);
+
+function ensureObject(value, fallback = {}) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : fallback;
+}
+
+export async function checkHealth(signal) {
+  const response = await api.get('/health', { signal });
+  return response.data;
+}
+
+export async function submitProblem(payload, signal) {
+  const body =
+    typeof payload === 'string'
+      ? { description: payload }
+      : ensureObject(payload);
+
+  const response = await api.post('/problem', body, { signal });
+  return response.data;
+}
+
+export async function fetchTimeline(signal) {
+  const response = await api.get('/timeline', { signal });
+  return response.data;
+}
+
+export async function fetchPatterns(signal) {
+  const response = await api.get('/patterns', { signal });
+  return response.data;
+}
+
+export async function runSimulation(payload, signal) {
+  const response = await api.post('/simulation', ensureObject(payload), {
+    signal,
+  });
+  return response.data;
+}
+
+export async function executeAction(actionId, signal) {
+  const response = await api.post(
+    '/action',
+    { action_id: actionId },
+    { signal }
+  );
+  return response.data;
+}
+
+export async function logResult(payload, signal) {
+  const response = await api.post('/result', ensureObject(payload), { signal });
+  return response.data;
+}
+
+export function getApiBase() {
+  return API_BASE;
+}
+
+export default api;

--- a/src/api.js
+++ b/src/api.js
@@ -6,6 +6,8 @@ const API_BASE =
     ? rawBase.trim().replace(/\/+$/, '')
     : 'http://localhost:8000';
 
+const PIOS_PREFIX = '/api/v1/pios';
+
 function extractErrorMessage(error) {
   if (axios.isCancel?.(error) || error?.code === 'ERR_CANCELED') {
     return 'Request cancelled';
@@ -60,23 +62,56 @@ function ensureObject(value, fallback = {}) {
     : fallback;
 }
 
+function toEntryPayload(payload) {
+  if (typeof payload === 'string') {
+    const text = payload.trim();
+    return {
+      entryType: 'text',
+      title: text.slice(0, 80) || 'Problem statement',
+      content: text,
+      sourceUri: null,
+    };
+  }
+
+  const input = ensureObject(payload);
+  if (typeof input.entryType === 'string' && typeof input.content === 'string') {
+    return {
+      entryType: input.entryType,
+      title:
+        typeof input.title === 'string' && input.title.trim()
+          ? input.title.trim()
+          : input.content.trim().slice(0, 80) || 'Problem statement',
+      content: input.content,
+      sourceUri: input.sourceUri ?? null,
+    };
+  }
+
+  const description =
+    typeof input.description === 'string' ? input.description.trim() : '';
+
+  return {
+    entryType: 'text',
+    title: description.slice(0, 80) || 'Problem statement',
+    content: description,
+    sourceUri: null,
+  };
+}
+
 export async function checkHealth(signal) {
   const response = await api.get('/health', { signal });
   return response.data;
 }
 
 export async function submitProblem(payload, signal) {
-  const body =
-    typeof payload === 'string'
-      ? { description: payload }
-      : ensureObject(payload);
+  const response = await api.post(`${PIOS_PREFIX}/entries`, toEntryPayload(payload), {
+    signal,
+  });
 
-  const response = await api.post('/problem', body, { signal });
   return response.data;
 }
 
 export async function fetchTimeline(signal) {
-  const response = await api.get('/timeline', { signal });
+  const response = await api.get(`${PIOS_PREFIX}/timeline`, { signal });
   return response.data;
 }
 

--- a/src/components/InputBox.jsx
+++ b/src/components/InputBox.jsx
@@ -1,0 +1,240 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { submitProblem } from '../api';
+
+const MAX_LENGTH = 4000;
+const MIN_LENGTH = 3;
+
+function normalizeInput(value) {
+  return value.replace(/\r\n/g, '\n').replace(/[^\S\n]+/g, ' ').trim();
+}
+
+function detectMetaPhrase(text) {
+  const raw = text.trim();
+
+  if (!raw) {
+    return {
+      mode: 'empty',
+      label: 'No input',
+      preview: null,
+    };
+  }
+
+  const upper = raw.toUpperCase();
+
+  if (
+    /^[A-Z0-9_:\-=()[\].,'" /+\n-]+$/i.test(raw) &&
+    /SYNAPSE|PROBLEM|SIMULATE|ACTION|RESULT|TIMELINE|PATTERN/.test(upper)
+  ) {
+    return {
+      mode: 'structured',
+      label: 'Structured command detected',
+      preview: raw,
+    };
+  }
+
+  if (
+    raw.includes(':') &&
+    /problem|simulate|action|result|timeline|pattern/i.test(raw)
+  ) {
+    return {
+      mode: 'semi-structured',
+      label: 'Command-like input detected',
+      preview: raw,
+    };
+  }
+
+  return {
+    mode: 'natural',
+    label: 'Natural language problem statement',
+    preview: `PROBLEM description="${normalizeInput(raw)}"`,
+  };
+}
+
+export default function InputBox({ onSubmitted }) {
+  const [problem, setProblem] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const abortRef = useRef(null);
+  const textareaRef = useRef(null);
+
+  const inputId = useId();
+  const helpId = useId();
+  const metaId = useId();
+  const statusId = useId();
+
+  const normalized = useMemo(() => normalizeInput(problem), [problem]);
+  const meta = useMemo(() => detectMetaPhrase(problem), [problem]);
+
+  const charsUsed = problem.length;
+  const charsRemaining = MAX_LENGTH - charsUsed;
+  const isTooShort = normalized.length > 0 && normalized.length < MIN_LENGTH;
+  const isTooLong = charsUsed > MAX_LENGTH;
+
+  const canSubmit = !loading && normalized.length >= MIN_LENGTH && !isTooLong;
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  async function handleSubmit(event) {
+    event?.preventDefault?.();
+
+    setError('');
+    setSuccessMessage('');
+
+    if (!normalized) {
+      setError('Please describe the issue before submitting.');
+      return;
+    }
+
+    if (normalized.length < MIN_LENGTH) {
+      setError(`Please enter at least ${MIN_LENGTH} characters.`);
+      return;
+    }
+
+    if (charsUsed > MAX_LENGTH) {
+      setError(`Input exceeds the ${MAX_LENGTH} character limit.`);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+
+    try {
+      const payload = {
+        description: normalized,
+        input_mode: meta.mode,
+        meta_phrase_preview: meta.preview,
+        submitted_at: new Date().toISOString(),
+      };
+
+      const result = await submitProblem(payload, controller.signal);
+
+      setProblem('');
+      setSuccessMessage('Problem submitted successfully.');
+
+      if (typeof onSubmitted === 'function') {
+        onSubmitted(result);
+      }
+
+      textareaRef.current?.focus();
+    } catch (err) {
+      if (err?.message !== 'Request cancelled') {
+        setError(err?.message || 'Failed to submit problem.');
+      }
+    } finally {
+      setLoading(false);
+      abortRef.current = null;
+    }
+  }
+
+  function handleClear() {
+    if (loading) return;
+
+    setProblem('');
+    setError('');
+    setSuccessMessage('');
+    textareaRef.current?.focus();
+  }
+
+  function handleChange(event) {
+    setProblem(event.target.value);
+
+    if (error) setError('');
+    if (successMessage) setSuccessMessage('');
+  }
+
+  function handleKeyDown(event) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 'Enter' && canSubmit) {
+      handleSubmit(event);
+    }
+  }
+
+  return (
+    <section className="input-box" aria-labelledby={`${inputId}-heading`}>
+      <div className="panel-header">
+        <div>
+          <h3 id={`${inputId}-heading`}>Problem Input</h3>
+          <p className="panel-subtitle">
+            Capture a problem statement or structured command.
+          </p>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} noValidate>
+        <label htmlFor={inputId} className="sr-only">
+          Describe the issue or enter a command
+        </label>
+
+        <textarea
+          id={inputId}
+          ref={textareaRef}
+          value={problem}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder="Describe the issue, task, or command..."
+          rows={8}
+          disabled={loading}
+          aria-invalid={Boolean(error)}
+          aria-describedby={`${helpId} ${problem.trim() ? metaId : ''} ${statusId}`.trim()}
+          spellCheck="true"
+          autoCapitalize="sentences"
+          autoCorrect="on"
+        />
+
+        <div id={helpId} className="input-meta-row">
+          <span className={charsRemaining < 120 ? 'warning-text' : 'muted-text'}>
+            {charsRemaining >= 0
+              ? `${charsRemaining} characters remaining`
+              : `${Math.abs(charsRemaining)} characters over limit`}
+          </span>
+
+          <span className="muted-text">Mode: {meta.label}</span>
+        </div>
+
+        {problem.trim() && meta.preview && (
+          <div id={metaId} className="meta-preview-box">
+            <div className="meta-preview-label">Preview</div>
+            <code>{meta.preview}</code>
+          </div>
+        )}
+
+        {isTooShort && (
+          <div className="validation-hint" role="note">
+            Add a little more detail so the system can classify it properly.
+          </div>
+        )}
+
+        <div className="input-actions">
+          <button type="submit" disabled={!canSubmit}>
+            {loading ? 'Submitting...' : 'Submit'}
+          </button>
+
+          <button
+            type="button"
+            className="button-secondary"
+            onClick={handleClear}
+            disabled={loading || (!problem && !error && !successMessage)}
+          >
+            Clear
+          </button>
+        </div>
+
+        <div id={statusId} className="status-stack" aria-live="polite">
+          {successMessage ? (
+            <div className="success-message">{successMessage}</div>
+          ) : null}
+
+          {error ? <div className="error">{error}</div> : null}
+        </div>
+      </form>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation

- Ensure ledger append operations produce a strict chain by preventing duplicate `previous_hash` values at the DB level.  
- Make `create_entry` resilient to concurrent append conflicts by retrying and rolling back on integrity violations.  
- Add a simple frontend API client and an input component to capture and submit problem statements to the backend.

### Description

- Add a `UniqueConstraint` on `previous_hash` in `LedgerEventTable` by modifying `backend/app/models/sql_models.py` to enforce uniqueness at the database level.  
- Update `PersonalIntelligenceService.create_entry` in `backend/app/services/pios_service.py` to perform up to 3 retries, catch `IntegrityError`, call `rollback()` on conflict, and raise a `RuntimeError` if retries are exhausted, and import `IntegrityError`.  
- Keep the advisory lock behavior via `_acquire_ledger_head_lock()` for Postgres to help serialize append operations.  
- Add a new frontend API wrapper `src/api.js` that centralizes `axios` configuration, error extraction, and helper functions like `checkHealth`, `submitProblem`, `fetchTimeline`, and others.  
- Add a new React component `src/components/InputBox.jsx` that normalizes input, detects simple structured commands, handles validation and submission using `submitProblem`, and provides client-side UX for clearing, feedback, and keyboard submit.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb4c74a508330ba04e496e6345768)